### PR TITLE
fix: p.85 Chap.5-35 「LambdaとAmazon Translateの連携」の Resource 名に書籍との齟齬があったため修正

### DIFF
--- a/sample_codes/cp05_Lambda_2/035_Lambda_Amazon_Translate/main.tf
+++ b/sample_codes/cp05_Lambda_2/035_Lambda_Amazon_Translate/main.tf
@@ -31,9 +31,9 @@ resource "aws_iam_role" "lambda_role" {
 }
 
 # Amazon Translateを動かすためのポリシー。リソースベースのポリシー制御ができないので、リソースは*でOK
-resource "aws_iam_role_policy" "s3_write_policy" {
   name        = "TranslatePolicy"
   role        = aws_iam_role.lambda_role.id
+resource "aws_iam_role_policy" "translate_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17",


### PR DESCRIPTION
表題の通りです。
`s3_write_policy` を `translate_policy` にしました。

対応不要なのであれば、クローズします。